### PR TITLE
LIMA_WRAP_BMP support.

### DIFF
--- a/limare/tests/Makefile.dump
+++ b/limare/tests/Makefile.dump
@@ -17,11 +17,11 @@ dump_wrap:
 ifeq ($(OS),android)
 	$(ADB) shell "rm $(DUMP_BMP)"
 	$(ADB) shell "rm $(DUMP_LOG)"
-	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(DUMP_LOG) $(INSTALL_DIR)/limare/dump"
+	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(DUMP_LOG) LIMA_WRAP_BMP=$(DUMP_BMP) $(INSTALL_DIR)/limare/dump"
 	$(ADB) pull $(DUMP_LOG)
 	$(ADB) pull $(DUMP_BMP)
 else
-	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(DUMP_LOG) $(INSTALL_DIR)/limare/dump)
+	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(DUMP_LOG) LIMA_WRAP_BMP=$(DUMP_BMP) $(INSTALL_DIR)/limare/dump)
 endif
 
 dump_run:

--- a/limare/tests/Makefile.egl
+++ b/limare/tests/Makefile.egl
@@ -22,11 +22,11 @@ egl_wrap:
 ifeq ($(OS),android)
 	$(ADB) shell "rm $(EGL_BMP)"
 	$(ADB) shell "rm $(EGL_LOG).0000"
-	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(EGL_LOG) $(INSTALL_DIR)/egl/$(NAME)"
+	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(EGL_LOG) LIMA_WRAP_BMP=$(EGL_BMP) $(INSTALL_DIR)/egl/$(NAME)"
 	$(ADB) pull $(EGL_LOG).0000
 	$(ADB) pull $(EGL_BMP)
 else
-	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(EGL_LOG) $(INSTALL_DIR)/egl/$(NAME))
+	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(EGL_LOG) LIMA_WRAP_BMP=$(EGL_BMP) $(INSTALL_DIR)/egl/$(NAME))
 endif
 
 egl_run: $(ADB)

--- a/limare/tests/Makefile.gles1
+++ b/limare/tests/Makefile.gles1
@@ -22,11 +22,11 @@ gles1_wrap:
 ifeq ($(OS),android)
 	$(ADB) shell "rm $(GLES1_BMP)"
 	$(ADB) shell "rm $(GLES1_LOG).0000"
-	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(GLES1_LOG) $(INSTALL_DIR)/gles1/$(NAME)"
+	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(GLES1_LOG) LIMA_WRAP_BMP=$(GLES1_BMP) $(INSTALL_DIR)/gles1/$(NAME)"
 	$(ADB) pull $(GLES1_LOG).0000
 	$(ADB) pull $(GLES1_BMP)
 else
-	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(GLES1_LOG) $(INSTALL_DIR)/gles1/$(NAME))
+	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(GLES1_LOG) LIMA_WRAP_BMP=$(GLES1_BMP) $(INSTALL_DIR)/gles1/$(NAME))
 endif
 
 gles1_run: $(ADB)

--- a/limare/tests/Makefile.limare
+++ b/limare/tests/Makefile.limare
@@ -17,11 +17,11 @@ limare_wrap:
 ifeq ($(OS),android)
 	$(ADB) shell "rm $(LIMARE_BMP)"
 	$(ADB) shell "rm $(LIMARE_LOG).0000"
-	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(LIMARE_LOG) $(INSTALL_DIR)/limare/$(NAME)"
+	$(ADB) shell "LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(LIMARE_LOG) LIMA_WRAP_BMP=$(LIMARE_BMP) $(INSTALL_DIR)/limare/$(NAME)"
 	$(ADB) pull $(LIMARE_LOG).0000
 	$(ADB) pull $(LIMARE_BMP)
 else
-	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(LIMARE_LOG) $(INSTALL_DIR)/limare/$(NAME))
+	$(shell LD_PRELOAD=libMali_wrap.so LIMA_WRAP_LOG=$(LIMARE_LOG) LIMA_WRAP_BMP=$(LIMARE_BMP) $(INSTALL_DIR)/limare/$(NAME))
 endif
 
 limare_run:

--- a/wrap/wrap.c
+++ b/wrap/wrap.c
@@ -1969,14 +1969,19 @@ mali_memory_dump(void)
 static void
 mali_wrap_bmp_dump(void)
 {
+	char *filename;
 	void *address = mali_address_retrieve(render_address);
 	char buffer[1024];
 
 	printf("%s: dumping frame %04d from address 0x%08X (%dx%d)\n",
 	       __func__, frame_count, render_address, render_width, render_height);
 
-	snprintf(buffer, sizeof(buffer), "/home/libv/lima/dump/lima.wrap.%04d.bmp",
-		 frame_count);
+	filename = getenv("LIMA_WRAP_BMP");
+	if (!filename)
+		filename = "/home/libv/lima/dump/lima.wrap.bmp";
+
+	snprintf(buffer, sizeof(buffer), "%s.%04d",
+		 filename, frame_count);
 
 	if (!address) {
 		printf("%s: Failed to dump bmp at 0x%x\n",


### PR DESCRIPTION
It adds support for LIMA_WRAP_BMP env variable, in the same way it was done for LIMA_WRAP_LOG,
so result file names has number of file (bitmap) appended.
Without this, it was always dumpings frames to /home/libv/lima/dump.