### PR TITLE
tests: Fix "_run" (limare/egl/gles1/dump) targets .

### DIFF
--- a/limare/tests/Makefile.dump
+++ b/limare/tests/Makefile.dump
@@ -28,7 +28,7 @@ dump_run:
 ifeq ($(OS),android)
 	$(ADB) shell $(INSTALL_DIR)limare/dump
 else
-	$(shell $(INSTALL_DIR)/limare/dump"
+	$(shell) $(INSTALL_DIR)/limare/dump
 endif
 
 dump_clean:

--- a/limare/tests/Makefile.egl
+++ b/limare/tests/Makefile.egl
@@ -33,7 +33,7 @@ egl_run: $(ADB)
 ifeq ($(OS),android)
 	$(ADB) shell $(INSTALL_DIR)egl/$(NAME)
 else
-	$(shell $(INSTALL_DIR)/egl/$(NAME)"
+	$(shell) $(INSTALL_DIR)/egl/$(NAME)
 endif
 
 egl_clean:

--- a/limare/tests/Makefile.gles1
+++ b/limare/tests/Makefile.gles1
@@ -33,7 +33,7 @@ gles1_run: $(ADB)
 ifeq ($(OS),android)
 	$(ADB) shell $(INSTALL_DIR)gles1/$(NAME)
 else
-	$(shell $(INSTALL_DIR)/gles1/$(NAME)"
+	$(shell) $(INSTALL_DIR)/gles1/$(NAME)
 endif
 
 gles1_clean:

--- a/limare/tests/Makefile.limare
+++ b/limare/tests/Makefile.limare
@@ -28,7 +28,7 @@ limare_run:
 ifeq ($(OS),android)
 	$(ADB) shell $(INSTALL_DIR)limare/$(NAME)
 else
-	$(shell $(INSTALL_DIR)/limare/$(NAME)"
+	$(shell) $(INSTALL_DIR)/limare/$(NAME)
 endif
 
 limare_clean:


### PR DESCRIPTION
Now limare/egl/gles1/dump_run works again.