### PR TITLE
Added support for aarch64 (armv8), ex:  odroid-c2

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -17,6 +17,8 @@ else ifeq ($(triplet), arm-linux-gnueabi)
 	OS = gnu
 else ifeq ($(triplet), arm-linux-gnueabihf)
 	OS = gnu
+else ifeq ($(triplet), aarch64-linux-gnu)
+	OS = gnu
 endif
 
 ifndef OS


### PR DESCRIPTION
# gcc -dumpmachine
aarch64-linux-gnu

Note:  it does not build completely, I will see if I can fix this error in another patch:
gcc -O3 -march=armv8-a+crc -mtune=cortex-a53 -fexpensive-optimizations -fprefetch-loop-arrays -fomit-frame-pointer -funroll-loops -ftree-vectorize -ffast-math -I../../../include -I../../lib/ -I../common   -c -MD -o ../common/egl_common.o ../common/egl_common.c
../common/egl_common.c:51:27: error: array type has incomplete element type ‘struct mali_native_window’
 struct mali_native_window native_window[1];
                           ^
../../../Makefile.post:8: recipe for target '../common/egl_common.o' failed
